### PR TITLE
Avoid race condition in angular bootstrap

### DIFF
--- a/popups/popup.html
+++ b/popups/popup.html
@@ -1,4 +1,4 @@
-<html ng-app="keepassApp" ng-csp>
+<html ng-csp>
 
 <head>
   <title>CKP</title>

--- a/popups/popup.js
+++ b/popups/popup.js
@@ -307,3 +307,9 @@ keepassApp.directive('staticInclude', function($http, $templateCache, $compile) 
 		});
 	};
 });
+
+angular.element(document).ready(function() {
+	setTimeout(function() {
+		angular.bootstrap(document, ['keepassApp']);
+	}, 0);
+});


### PR DESCRIPTION
Currently, Chrome computes the height of a popup window by
evaluating the size of the body and animating the window to be that
size. If angular is initializing during this process, Chrome will
compute an invalid size for the popup window. By delaying the
bootstrap process until after the event thread runs, we cause
Chrome to re-render and re-animate the popup, fixing the issue
where the popup shows with the top half truncated.